### PR TITLE
Fix response value in TransactionFees POST API call and implement Uni…

### DIFF
--- a/lib/Api/TransactionFeesApi.php
+++ b/lib/Api/TransactionFeesApi.php
@@ -89,54 +89,53 @@ class TransactionFeesApi
         $this->apiClient = $apiClient;
         return $this;
     }
-  
-    
+
     /**
-     * transactionFeesPost
+     * transactionFeesGet
      *
-     * Calculates and returns transaction fees for a given subtotal amount based on the account.
+     * Calculates and returns transaction fees for a given net amount due based on the account.
      *
-     * @param \Swagger\Client\Model\PostTransactionFeesRequestModel $post_transaction_fees_request_model Subtotal from which to calculate the transaction fees. (required)
-     * @param string $impersonation_account_key  (optional, default to )
-     * @return void
+     * @param string $amount input value of amount. (required)
+     * @param string $impersonation_account_key The key that allows impersonation of another account for which the amount is being processed. Only specify a value if the account being impersonated is different from the account that is submitting this request. (optional, default to )
+     * @return \Swagger\Client\Model\GetTransactionFeesResponseModel
      * @throws \Swagger\Client\ApiException on non-2xx response
      */
-    public function transactionFeesPost($post_transaction_fees_request_model, $impersonation_account_key = null)
+    public function transactionFeesGet($amount, $impersonation_account_key = null)
     {
-        list($response, $statusCode, $httpHeader) = $this->transactionFeesPostWithHttpInfo ($post_transaction_fees_request_model, $impersonation_account_key);
+        list($response, $statusCode, $httpHeader) = $this->transactionFeesGetWithHttpInfo ($amount, $impersonation_account_key);
         return $response; 
     }
 
 
     /**
-     * transactionFeesPostWithHttpInfo
+     * transactionFeesGetWithHttpInfo
      *
-     * Calculates and returns transaction fees for a given subtotal amount based on the account.
+     * Calculates and returns transaction fees for a given net amount due based on the account
      *
-     * @param \Swagger\Client\Model\PostTransactionFeesRequestModel $post_transaction_fees_request_model Subtotal from which to calculate the transaction fees. (required)
-     * @param string $impersonation_account_key  (optional, default to )
-     * @return Array of null, HTTP status code, HTTP response headers (array of strings)
+     * @param string $amountValue - net amount. (required)
+     * @param string $impersonation_account_key The key that allows impersonation of another account for which the amount is being processed. Only specify a value if the account being impersonated is different from the account that is submitting this request. (optional, default to )
+     * @return Array of \Swagger\Client\Model\GetTransactionFeesResponseModel, HTTP status code, HTTP response headers (array of strings)
      * @throws \Swagger\Client\ApiException on non-2xx response
      */
-    public function transactionFeesPostWithHttpInfo($post_transaction_fees_request_model, $impersonation_account_key = null)
+    public function transactionFeesGetWithHttpInfo($amountValue, $impersonation_account_key = null)
     {
         
-        // verify the required parameter 'post_transaction_fees_request_model' is set
-        if ($post_transaction_fees_request_model === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $post_transaction_fees_request_model when calling transactionFeesPost');
+        // verify the required parameter 'amount' is set
+        if ($amountValue === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $amountValue when calling transactionFeesGet');
         }
   
         // parse inputs
-        $resourcePath = "/api/v1/transactionFees";
+        $resourcePath = "/api/v1/transactionFees?amount={amountValue}";
         $httpBody = '';
         $queryParams = array();
         $headerParams = array();
         $formParams = array();
         $_header_accept = ApiClient::selectHeaderAccept(array('application/json', 'text/json', 'application/xml', 'text/xml'));
         if (!is_null($_header_accept)) {
-            $headerParams['Accept'] = $_header_accept;
+            $headerParams['Accept'] = "application/json";
         }
-        $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array('application/json','text/json','application/xml','text/xml','application/x-www-form-urlencoded'));
+        $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array());
   
         
         // header params
@@ -144,16 +143,20 @@ class TransactionFeesApi
         if ($impersonation_account_key !== null) {
             $headerParams['impersonationAccountKey'] = $this->apiClient->getSerializer()->toHeaderValue($impersonation_account_key);
         }
+        // path params
         
+        if ($amountValue !== null) {
+            $resourcePath = str_replace(
+                "{" . "amountValue" . "}",
+                $this->apiClient->getSerializer()->toPathValue($amountValue),
+                $resourcePath
+            );
+        }
         // default format to json
         $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         
-        // body params
-        $_tempBody = null;
-        if (isset($post_transaction_fees_request_model)) {
-            $_tempBody = $post_transaction_fees_request_model;
-        }
+        
   
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -165,15 +168,23 @@ class TransactionFeesApi
         // make the API Call
         try {
             list($response, $statusCode, $httpHeader) = $this->apiClient->callApi(
-                $resourcePath, 'POST',
+                $resourcePath, 'GET',
                 $queryParams, $httpBody,
-                $headerParams
+                $headerParams, '\Swagger\Client\Model\GetTransactionFeesResponseModel'
             );
             
-            return array($response, $statusCode, $httpHeader);
+            if (!$response) {
+                return array(null, $statusCode, $httpHeader);
+            }
+
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\GetTransactionFeesResponseModel', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
+            case 200:
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\GetTransactionFeesResponseModel', $e->getResponseHeaders());
+                $e->setResponseObject($data);
+                break;
             case 400:
                 $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'map[string,\Swagger\Client\Model\ObjectDictionary]', $e->getResponseHeaders());
                 $e->setResponseObject($data);
@@ -183,5 +194,4 @@ class TransactionFeesApi
             throw $e;
         }
     }
-    
 }

--- a/lib/Api/TransactionFeesApi.php
+++ b/lib/Api/TransactionFeesApi.php
@@ -170,7 +170,7 @@ class TransactionFeesApi
                 $headerParams
             );
             
-            return array(null, $statusCode, $httpHeader);
+            return array($response, $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 

--- a/lib/Model/GetTransactionFeesResponseModel.php
+++ b/lib/Model/GetTransactionFeesResponseModel.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PostTransactionFeesResponseModel
+ * GetTransactionFeesResponseModel
  *
  * PHP version 5
  *
@@ -35,7 +35,7 @@ namespace Swagger\Client\Model;
 
 use \ArrayAccess;
 /**
- * PostTransactionFeesResponseModel Class Doc Comment
+ * GetTransactionFeesResponseModel Class Doc Comment
  *
  * @category    Class
  * @description 
@@ -44,7 +44,7 @@ use \ArrayAccess;
  * @license     http://www.apache.org/licenses/LICENSE-2.0 Apache Licene v2
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class PostTransactionFeesResponseModel implements ArrayAccess
+class GetTransactionFeesResponseModel implements ArrayAccess
 {
     /**
       * Array of property to type mappings. Used for (de)serialization 

--- a/lib/Tests/TransactionsFixtureTest.php
+++ b/lib/Tests/TransactionsFixtureTest.php
@@ -44,7 +44,7 @@ use Swagger\Client\Api\TransactionsApi;
 use Swagger\Client\Api\TransactionFeesApi;
 use Swagger\Client\Model\PostTransactionRequestModel;
 use Swagger\Client\Model\PostVoidTransactionRequestModel;
-use Swagger\Client\Model\PostTransactionFeesRequestModel;
+use Swagger\Client\Model\GetTransactionFeesResponseModel;
 require_once '../../vendor/autoload.php';
 
 /**
@@ -89,28 +89,24 @@ class TransactionsFixtureTest extends TestCase
         parent::tearDown();
     }
     
-    /**
-     * Test case for Posting TransactionFees API
-     *
-     * POST API call for a random amount and returns object  
-     * consisting of achPayerFee and creditCardPayerFee fields.
-     */
-    public function testShould_Successfully_Post_TransactionFees_API()
+    public function testShould_Successfully_GetTransactionFees_API()
     {
         //Get random amount between 1 and 1000
         $randomAmount = rand(1,1000);  
-        //uncomment print_r calls in this method to inspect request and response objects
-        //print_r($randomAmount);
-        
-        $postTransactionFeesRequestModel = new PostTransactionFeesRequestModel();
-        $postTransactionFeesRequestModel->setAmount($randomAmount);
+        print_r($randomAmount);              
+        print_r("\r\n");  
 
-        //print_r($postTransactionFeesRequestModel);
+        $transactionFeesResponseModel = new GetTransactionFeesResponseModel();
+        $transactionFeesResponseModel = $this->transactionFeesApi->transactionFeesGet($randomAmount);
+        print_r($transactionFeesResponseModel);
+        print_r("\r\n");
+        print_r($transactionFeesResponseModel->getAchPayerFee());
+        print_r("\r\n");
+        print_r($transactionFeesResponseModel->getCreditCardPayerFee());
 
-        $transactionFeesResponseModel = new PostTransactionFeesResponseModel();
-        $transactionFeesResponseModel = $this->transactionFeesApi->transactionFeesPost($postTransactionFeesRequestModel);
-        //print_r($transactionFeesResponseModel);
         $this->assertNotNull($transactionFeesResponseModel);
+        $this->assertTrue($transactionFeesResponseModel->getAchPayerFee() != 0);
+        $this->assertTrue($transactionFeesResponseModel->getCreditCardPayerFee() != 0);
     }
     
     /**
@@ -122,7 +118,7 @@ class TransactionsFixtureTest extends TestCase
     public function testShould_Successfully_Process_And_Void_Credit_Card() {	
         
         //Get random amount between 1 and 1000
-        $randomAmount = rand(1,1000);  
+        $randomAmount = rand(1,1000);          
         
         $postTransactionRequestModel = new PostTransactionRequestModel();
         $postTransactionRequestModel->setPayer("John Smith");

--- a/lib/Tests/TransactionsFixtureTest.php
+++ b/lib/Tests/TransactionsFixtureTest.php
@@ -41,8 +41,10 @@ use \Swagger\Client\ObjectSerializer;
 use Swagger\Client\Model\CreditCardInformationModel;
 use Swagger\Client\Model\AttributeValueModel;
 use Swagger\Client\Api\TransactionsApi;
+use Swagger\Client\Api\TransactionFeesApi;
 use Swagger\Client\Model\PostTransactionRequestModel;
 use Swagger\Client\Model\PostVoidTransactionRequestModel;
+use Swagger\Client\Model\PostTransactionFeesRequestModel;
 require_once '../../vendor/autoload.php';
 
 /**
@@ -58,6 +60,7 @@ class TransactionsFixtureTest extends TestCase
 {
 
     private $transactionsApi;   
+    private $transactionFeesApi;
     /**
      * Prepares the environment before running a test.
      */
@@ -73,6 +76,7 @@ class TransactionsFixtureTest extends TestCase
         $apiClient = new ApiClient($configuration);
 		
         $this->transactionsApi = new TransactionsApi($apiClient);
+        $this->transactionFeesApi = new TransactionFeesApi($apiClient);
     }
     
     /**
@@ -81,9 +85,33 @@ class TransactionsFixtureTest extends TestCase
     public function tearDown()
     {
         $this->transactionsApi = null;
+        $this->transactionFeesApi = null;
         parent::tearDown();
     }
     
+    /**
+     * Test case for Posting TransactionFees API
+     *
+     * POST API call for a random amount and returns object  
+     * consisting of achPayerFee and creditCardPayerFee fields.
+     */
+    public function testShould_Successfully_Post_TransactionFees_API()
+    {
+        //Get random amount between 1 and 1000
+        $randomAmount = rand(1,1000);  
+        //uncomment print_r calls in this method to inspect request and response objects
+        //print_r($randomAmount);
+        
+        $postTransactionFeesRequestModel = new PostTransactionFeesRequestModel();
+        $postTransactionFeesRequestModel->setAmount($randomAmount);
+
+        //print_r($postTransactionFeesRequestModel);
+
+        $transactionFeesResponseModel = new PostTransactionFeesResponseModel();
+        $transactionFeesResponseModel = $this->transactionFeesApi->transactionFeesPost($postTransactionFeesRequestModel);
+        //print_r($transactionFeesResponseModel);
+        $this->assertNotNull($transactionFeesResponseModel);
+    }
     
     /**
      * Test case for TransactionsFixture


### PR DESCRIPTION
Fixed issue with returning valid response object from TransactionFees
POST API call. 
Also, implemented unit test case to demonstrate successful TransactionFees Post API call for a random amount between 1 and 1000.